### PR TITLE
Allow '-' character in youtube url

### DIFF
--- a/OEmbed.Test/ProvidersTests/YoutubeTests.cs
+++ b/OEmbed.Test/ProvidersTests/YoutubeTests.cs
@@ -19,6 +19,7 @@ namespace OEmbed.Test.ProvidersTests
         [InlineData("https://youtu.be/LKWFkELeYwc")]
         [InlineData("http://youtu.be/LKWFkELeYwc")]
         [InlineData("https://www.youtu.be/LKWFkELeYwc")]
+        [InlineData("https://youtu.be/LKWFkE-LeYwc")]
         [InlineData("https://www.youtube.com/watch?v=LKWFkELeYwc")]
         [InlineData("https://www.youtube.com/embed/LKWFkELeYwc?autoplay=1")]
         [InlineData("https://m.youtube.com/watch?v=LKWFkELeYwc&feature=youtu.be")]

--- a/OEmbed/Providers/YoutubeProvider.cs
+++ b/OEmbed/Providers/YoutubeProvider.cs
@@ -19,7 +19,7 @@ namespace HeyRed.OEmbed.Providers
             });
 
             AddScheme(
-                matcher: new RegexMatcher(@"/(?:embed/|video/|shorts/|playlist\?list=|watch\?v=)?([\w]+)(?:[\w\&\?\=\.]+)?"),
+                matcher: new RegexMatcher(@"/(?:embed/|video/|shorts/|playlist\?list=|watch\?v=)?([\w|-]+)(?:[\w\&\?\=\.]+)?"),
                 apiEndpoint: "https://www.youtube.com/oembed",
                 resourceType: ResourceType.Video);
         }


### PR DESCRIPTION
YoutubeProvider didn't accept urls with hyphen - e.g. `https://www.youtube.com/watch?v=ospQ06jJe-I`